### PR TITLE
Add Nix flake for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Nix build output symlink
+/result
+
 /.metadata/
 /workspace/
 cachedir/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1774244481,
+        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,23 @@
         "type": "github"
       }
     },
+    "modelio-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774300378,
+        "narHash": "sha256-FPLX9xJ5puFJX0N4DEVKSYRy7qE9ZfCmHbS8Id2zyrA=",
+        "owner": "randomizedcoder",
+        "repo": "Modelio",
+        "rev": "53eb60381eac57b313ea862208b3d38652bf59b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "randomizedcoder",
+        "repo": "Modelio",
+        "rev": "53eb60381eac57b313ea862208b3d38652bf59b9",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1751274312,
@@ -37,6 +54,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "modelio-src": "modelio-src",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,14 @@
+# Modelio – open-source UML/BPMN modeling tool
+#
+# Usage:
+#   nix build          Build Modelio
+#   nix run            Build and launch Modelio
+#   nix develop        Enter dev shell (Maven + JDK 11 + native libs)
+#   nix build .#container        Build OCI container image
+#   nix run .#container-run      Load and run container with Docker
+#   nix flake check              Run smoke tests
+#
+# See ./nix/README.md for full documentation.
 {
   description = "Modelio – open-source UML/BPMN modeling tool";
 
@@ -9,36 +20,34 @@
     # This ensures the maven deps FOD only changes when you explicitly
     # run: nix flake update modelio-src
     modelio-src = {
-      url = "github:randomizedcoder/Modelio/53eb60381eac57b313ea862208b3d38652bf59b9";
+      url =
+        "github:randomizedcoder/Modelio/53eb60381eac57b313ea862208b3d38652bf59b9";
       flake = false;
     };
   };
 
-  outputs =
-    {
-      nixpkgs,
-      flake-utils,
-      modelio-src,
-      ...
-    }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
-      system:
+  outputs = { nixpkgs, flake-utils, modelio-src, ... }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        modelio = pkgs.callPackage ./nix/package.nix { inherit modelio-src; };
-      in
-      {
+        mvnDeps =
+          pkgs.callPackage ./nix/maven-deps.nix { inherit modelio-src; };
+        modelio =
+          pkgs.callPackage ./nix/package.nix { inherit modelio-src mvnDeps; };
+        container = pkgs.callPackage ./nix/container.nix { inherit modelio; };
+      in {
         packages = {
           default = modelio;
           inherit modelio;
-          container = pkgs.callPackage ./nix/container.nix { inherit modelio; };
+          inherit container;
+          container-run =
+            pkgs.callPackage ./nix/container-run.nix { inherit container; };
         };
 
         devShells.default = pkgs.callPackage ./nix/shell.nix { };
 
         checks.default = pkgs.callPackage ./nix/test.nix { inherit modelio; };
 
-        formatter = pkgs.nixfmt;
-      }
-    );
+        formatter = pkgs.nixfmt-classic;
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   description = "Modelio – open-source UML/BPMN modeling tool";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
 
     # Pinned Modelio source for maven dependency fetching.

--- a/flake.nix
+++ b/flake.nix
@@ -4,19 +4,28 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
+
+    # Pinned Modelio source for maven dependency fetching.
+    # This ensures the maven deps FOD only changes when you explicitly
+    # run: nix flake update modelio-src
+    modelio-src = {
+      url = "github:randomizedcoder/Modelio/53eb60381eac57b313ea862208b3d38652bf59b9";
+      flake = false;
+    };
   };
 
   outputs =
     {
       nixpkgs,
       flake-utils,
+      modelio-src,
       ...
     }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        modelio = pkgs.callPackage ./nix/package.nix { };
+        modelio = pkgs.callPackage ./nix/package.nix { inherit modelio-src; };
       in
       {
         packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Modelio – open-source UML/BPMN modeling tool";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        modelio = pkgs.callPackage ./nix/package.nix { };
+      in
+      {
+        packages = {
+          default = modelio;
+          inherit modelio;
+          container = pkgs.callPackage ./nix/container.nix { inherit modelio; };
+        };
+
+        devShells.default = pkgs.callPackage ./nix/shell.nix { };
+
+        checks.default = pkgs.callPackage ./nix/test.nix { inherit modelio; };
+
+        formatter = pkgs.nixfmt;
+      }
+    );
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -8,12 +8,14 @@ Modelio using [Nix flakes](https://nixos.wiki/wiki/Flakes).
 - [Quick Start](#quick-start)
 - [What This Provides](#what-this-provides)
 - [How It Works](#how-it-works)
+  - [Maven Dependencies (maven-deps.nix)](#maven-dependencies-maven-depsnix)
   - [Source Build (package.nix)](#source-build-packagenix)
   - [Dev Shell (shell.nix)](#dev-shell-shellnix)
   - [Container (container.nix)](#container-containernix)
   - [Smoke Test (test.nix)](#smoke-test-testnix)
 - [File Layout](#file-layout)
 - [Design Decisions](#design-decisions)
+- [Reproducibility Strategy](#reproducibility-strategy)
 - [Updating the FOD Hash](#updating-the-fod-hash)
 
 ## Quick Start
@@ -31,6 +33,9 @@ nix develop
 # Build an OCI container image
 nix build .#container
 
+# Build container and run with Docker (handles X11 forwarding)
+nix run .#container-run
+
 # Run smoke tests
 nix flake check
 ```
@@ -41,6 +46,7 @@ nix flake check
 |---------------------|-------------|
 | `packages.default` / `packages.modelio` | Full source build of Modelio 5.4.1 with desktop entry and wrapper script |
 | `packages.container` | Minimal OCI container image (layered, with bash and CA certs) |
+| `packages.container-run` | Script that loads the container into Docker and launches Modelio with X11 forwarding |
 | `devShells.default` | Dev shell with Maven, JDK 11, native libs, and auto-generated `toolchains.xml` |
 | `checks.default` | xvfb-based smoke test that verifies the built binary starts correctly |
 
@@ -52,39 +58,47 @@ The flake (`flake.nix`) delegates to module files in `nix/`:
 
 ```
 flake.nix
-  ├── nix/package.nix   → packages.modelio / packages.default
-  ├── nix/shell.nix     → devShells.default
-  ├── nix/container.nix → packages.container
-  └── nix/test.nix      → checks.default
+  ├── nix/lib.nix         → shared constants and shell snippets
+  ├── nix/maven-deps.nix  → packages.modelio (FOD dependency cache)
+  ├── nix/package.nix     → packages.modelio / packages.default
+  ├── nix/shell.nix       → devShells.default
+  ├── nix/container.nix     → packages.container
+  ├── nix/container-run.nix → packages.container-run
+  └── nix/test.nix          → checks.default
 ```
+
+### Maven Dependencies (`maven-deps.nix`)
+
+A **fixed-output derivation (FOD)** that runs with network access. Executes
+`mvn install` on `AGGREGATOR/pom.xml` and `mvn package` on `products/pom.xml`,
+caching all Maven, Tycho, and P2 dependencies into `$out/.m2/repository`.
+The result is pinned by a SHA-256 content hash (`outputHash`).
+
+Uses pinned source (`modelio-src` flake input) so local edits don't invalidate
+the cache. Update the pin with: `nix flake update modelio-src`.
 
 ### Source Build (`package.nix`)
 
-The build uses a **two-phase fixed-output derivation (FOD)** approach to work
-within Nix's sandboxed, network-less build environment:
+Builds fully offline (`--offline`) using the cached repo from `maven-deps.nix`.
+Copies the repo to a writable temp directory (Tycho needs to write `.tycholock`
+files), then runs the same Maven commands.
 
-1. **`mvnDeps` (FOD)** — runs with network access. Executes
-   `mvn install` on `AGGREGATOR/pom.xml` and `mvn package` on `products/pom.xml`,
-   caching all Maven, Tycho, and P2 dependencies into `$out/.m2/repository`.
-   The result is pinned by a SHA-256 content hash (`outputHash`).
+The install phase extracts the product tarball from
+`products/target/products/`, replaces the bundled JRE with a symlink to the
+Nix-provided JDK, and creates a wrapper script that sets:
+- `LD_LIBRARY_PATH` for GTK, X11, WebKit, and other native libraries
+- `JAVA_HOME` pointing to the runtime JDK
+- JVM flags: `-Xms1024m -Xmx4096m`, UTF-8 Python console, WebKit TLS config
+- A `.desktop` entry and icon
 
-2. **Main derivation** — builds fully offline (`--offline`) using the cached
-   repo from step 1. Copies the repo to a writable temp directory (Tycho needs
-   to write `.tycholock` files), then runs the same Maven commands.
-
-3. **Install phase** — extracts the product tarball from
-   `products/target/products/`, replaces the bundled JRE with a symlink to the
-   Nix-provided JDK, and creates a wrapper script that sets:
-   - `LD_LIBRARY_PATH` for GTK, X11, WebKit, and other native libraries
-   - `JAVA_HOME` pointing to the runtime JDK
-   - JVM flags: `-Xms1024m -Xmx4096m`, UTF-8 Python console, WebKit TLS config
-   - A `.desktop` entry and icon
+Shared values (toolchains, build.properties fixup, runtime library list) are
+imported from `lib.nix` to avoid duplication.
 
 ### Dev Shell (`shell.nix`)
 
 `mkShell` with Maven and JDK 11 on `PATH`, plus native library dependencies in
-`buildInputs`. The `shellHook` auto-generates `~/.m2/toolchains.xml` and prints
-build instructions:
+`buildInputs`. The `shellHook` imports `setupToolchains` from `lib.nix` and
+prints build instructions:
 
 ```
 1. mvn clean install -f AGGREGATOR/pom.xml
@@ -100,14 +114,19 @@ Modelio version. Contents:
 - Modelio package
 - `bash`, `coreutils`, CA certificates
 - `DISPLAY=:99`, SSL cert path pre-configured
-- Volumes at `/workspace` and `/root/.modelio`
 
-Load and run:
+Load and run manually:
 
 ```bash
 nix build .#container
 docker load < result
 docker run --rm -e DISPLAY=:0 -v /tmp/.X11-unix:/tmp/.X11-unix modelio:5.4.1
+```
+
+Or use the one-shot launcher (handles X11 auth, mounts `~/.modelio` and `$PWD`):
+
+```bash
+nix run .#container-run
 ```
 
 ### Smoke Test (`test.nix`)
@@ -127,9 +146,12 @@ The test:
 |------|---------|
 | `flake.nix` | Flake entry point — wires outputs to `nix/*.nix` modules |
 | `flake.lock` | Pinned input revisions (nixpkgs 24.11, flake-utils) |
-| `nix/package.nix` | Modelio source build (FOD + main derivation) |
+| `nix/lib.nix` | Shared constants and shell snippets (version, toolchains, runtime libs) |
+| `nix/maven-deps.nix` | Fixed-output derivation — Maven/Tycho dependency cache |
+| `nix/package.nix` | Modelio source build (offline, using cached deps) |
 | `nix/shell.nix` | Development shell |
 | `nix/container.nix` | OCI container image |
+| `nix/container-run.nix` | One-shot script to load and run the container with Docker |
 | `nix/test.nix` | Smoke test check |
 | `nix/README.md` | This file |
 
@@ -174,13 +196,58 @@ that we control wrapper arguments ourselves via `makeWrapper` +
 
 ### 6. FOD hash maintenance
 
-The `outputHash` in `mvnDeps` pins the exact set of fetched dependencies. When
-upstream dependencies change, this hash must be updated. See below.
+The `outputHash` in `maven-deps.nix` pins the exact set of fetched dependencies.
+When upstream dependencies change, this hash must be updated. See below.
+
+## Reproducibility Strategy
+
+Maven builds are non-deterministic by default — metadata files contain
+timestamps and JAR archives embed build dates. The FOD in `maven-deps.nix`
+applies four mitigations to ensure the dependency cache hashes reproducibly:
+
+### 1. Delete ephemeral metadata files
+
+Files like `*.lastUpdated`, `resolver-status.properties`, and
+`_remote.repositories` contain download timestamps and local path references.
+These are removed in the FOD `installPhase`. This matches the pattern used by
+nixpkgs' [`build-maven-package.nix`][nixpkgs-maven].
+
+### 2. Delete `maven-metadata-*.xml`
+
+These files contain `<lastUpdated>` timestamp elements that vary between builds.
+Removing them follows the approach used by other nixpkgs Maven packages (e.g.,
+tuxguitar).
+
+### 3. Set `-Dproject.build.outputTimestamp`
+
+The Maven property `project.build.outputTimestamp=1980-01-01T00:00:02Z` forces
+all build outputs (JARs, manifests) to use a fixed timestamp instead of the
+current time. This is standard practice in nixpkgs (scenebuilder, nzbhydra2,
+verapdf) and is documented in the [Maven reproducible builds guide][maven-repro].
+
+### 4. `dontFixup = true`
+
+Prevents Nix fixup phases (strip, patchelf, etc.) from modifying the FOD output,
+which could introduce non-determinism.
+
+### References
+
+- [nixpkgs Java/Maven documentation][nixpkgs-java]
+- [nixpkgs `build-maven-package.nix`][nixpkgs-maven] — canonical Maven FOD pattern
+- [Maven reproducible builds guide][maven-repro] — documents `project.build.outputTimestamp`
+- [Reproducible Builds: JVM][repro-jvm] — JVM-specific reproducibility guidance
+- [nixpkgs #278518][nixpkgs-issue] — tracking issue for non-deterministic Java apps
+
+[nixpkgs-java]: https://nixos.org/manual/nixpkgs/stable/#sec-language-java
+[nixpkgs-maven]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ma/maven/build-maven-package.nix
+[maven-repro]: https://maven.apache.org/guides/mini/guide-reproducible-builds.html
+[repro-jvm]: https://reproducible-builds.org/docs/jvm/
+[nixpkgs-issue]: https://github.com/NixOS/nixpkgs/issues/278518
 
 ## Updating the FOD Hash
 
 When Maven dependencies change (e.g., after bumping a version in a `pom.xml`),
-the `outputHash` in `nix/package.nix` must be updated:
+the `outputHash` in `nix/maven-deps.nix` must be updated:
 
 1. Set the hash to a placeholder:
    ```nix

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,206 @@
+# Nix Integration for Modelio
+
+Reproducible builds, development shells, OCI containers, and smoke tests for
+Modelio using [Nix flakes](https://nixos.wiki/wiki/Flakes).
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [What This Provides](#what-this-provides)
+- [How It Works](#how-it-works)
+  - [Source Build (package.nix)](#source-build-packagenix)
+  - [Dev Shell (shell.nix)](#dev-shell-shellnix)
+  - [Container (container.nix)](#container-containernix)
+  - [Smoke Test (test.nix)](#smoke-test-testnix)
+- [File Layout](#file-layout)
+- [Design Decisions](#design-decisions)
+- [Updating the FOD Hash](#updating-the-fod-hash)
+
+## Quick Start
+
+```bash
+# Build and run Modelio
+nix run
+
+# Build without running
+nix build
+
+# Enter a development shell (Maven + JDK 11 + native libs)
+nix develop
+
+# Build an OCI container image
+nix build .#container
+
+# Run smoke tests
+nix flake check
+```
+
+## What This Provides
+
+| Flake output        | Description |
+|---------------------|-------------|
+| `packages.default` / `packages.modelio` | Full source build of Modelio 5.4.1 with desktop entry and wrapper script |
+| `packages.container` | Minimal OCI container image (layered, with bash and CA certs) |
+| `devShells.default` | Dev shell with Maven, JDK 11, native libs, and auto-generated `toolchains.xml` |
+| `checks.default` | xvfb-based smoke test that verifies the built binary starts correctly |
+
+All outputs target `x86_64-linux` only.
+
+## How It Works
+
+The flake (`flake.nix`) delegates to module files in `nix/`:
+
+```
+flake.nix
+  ├── nix/package.nix   → packages.modelio / packages.default
+  ├── nix/shell.nix     → devShells.default
+  ├── nix/container.nix → packages.container
+  └── nix/test.nix      → checks.default
+```
+
+### Source Build (`package.nix`)
+
+The build uses a **two-phase fixed-output derivation (FOD)** approach to work
+within Nix's sandboxed, network-less build environment:
+
+1. **`mvnDeps` (FOD)** — runs with network access. Executes
+   `mvn install` on `AGGREGATOR/pom.xml` and `mvn package` on `products/pom.xml`,
+   caching all Maven, Tycho, and P2 dependencies into `$out/.m2/repository`.
+   The result is pinned by a SHA-256 content hash (`outputHash`).
+
+2. **Main derivation** — builds fully offline (`--offline`) using the cached
+   repo from step 1. Copies the repo to a writable temp directory (Tycho needs
+   to write `.tycholock` files), then runs the same Maven commands.
+
+3. **Install phase** — extracts the product tarball from
+   `products/target/products/`, replaces the bundled JRE with a symlink to the
+   Nix-provided JDK, and creates a wrapper script that sets:
+   - `LD_LIBRARY_PATH` for GTK, X11, WebKit, and other native libraries
+   - `JAVA_HOME` pointing to the runtime JDK
+   - JVM flags: `-Xms1024m -Xmx4096m`, UTF-8 Python console, WebKit TLS config
+   - A `.desktop` entry and icon
+
+### Dev Shell (`shell.nix`)
+
+`mkShell` with Maven and JDK 11 on `PATH`, plus native library dependencies in
+`buildInputs`. The `shellHook` auto-generates `~/.m2/toolchains.xml` and prints
+build instructions:
+
+```
+1. mvn clean install -f AGGREGATOR/pom.xml
+2. mvn package -f products/pom.xml -Pproduct.org,platform.linux
+   Output: products/target/products/*linux*.tar.gz
+```
+
+### Container (`container.nix`)
+
+Uses `dockerTools.buildLayeredImage` to produce an OCI image tagged with the
+Modelio version. Contents:
+
+- Modelio package
+- `bash`, `coreutils`, CA certificates
+- `DISPLAY=:99`, SSL cert path pre-configured
+- Volumes at `/workspace` and `/root/.modelio`
+
+Load and run:
+
+```bash
+nix build .#container
+docker load < result
+docker run --rm -e DISPLAY=:0 -v /tmp/.X11-unix:/tmp/.X11-unix modelio:5.4.1
+```
+
+### Smoke Test (`test.nix`)
+
+A `writeShellApplication` wrapped in `runCommand` (so it runs as a Nix check).
+The test:
+
+1. Verifies the `modelio` binary exists and is executable
+2. Confirms the JRE symlink is in place
+3. Launches Modelio under `xvfb-run`, waits 15 seconds, and checks the process
+   is still alive
+4. Kills the process and confirms clean exit
+
+## File Layout
+
+| File | Purpose |
+|------|---------|
+| `flake.nix` | Flake entry point — wires outputs to `nix/*.nix` modules |
+| `flake.lock` | Pinned input revisions (nixpkgs 24.11, flake-utils) |
+| `nix/package.nix` | Modelio source build (FOD + main derivation) |
+| `nix/shell.nix` | Development shell |
+| `nix/container.nix` | OCI container image |
+| `nix/test.nix` | Smoke test check |
+| `nix/README.md` | This file |
+
+## Design Decisions
+
+### 1. JDK 11 for build, latest JDK for runtime
+
+Tycho 2.2.0 (used by Modelio's build) doesn't recognize execution environments
+beyond ~JavaSE-16, so the build must use `jdk11`. The installed application
+links to the default Nix `jdk` (latest OpenJDK) for runtime — Java is
+backward-compatible for running bytecode compiled with older versions.
+
+### 2. Dual toolchain entries (JavaSE-1.8 + JavaSE-11)
+
+Some OSGi bundles in the Modelio source declare
+`Bundle-RequiredExecutionEnvironment: JavaSE-1.8`. Tycho's `useJDK=BREE` mode
+demands a matching toolchain entry for each referenced execution environment.
+Both entries point to `jdk11`, which can compile Java 8 bytecode via
+`--release 8`.
+
+### 3. Dynamic missing-directory creation
+
+Approximately 26 directories referenced in `build.properties` `bin.includes`
+fields across the source tree are not tracked by git (empty directories). Rather
+than maintaining a static list, a `find`+`grep` script at build time parses
+every `build.properties` file and creates any missing directories automatically.
+
+### 4. Writable repo copy for Tycho lock files
+
+The FOD output lives in `/nix/store` and is read-only. Tycho creates
+`.tycholock` files inside the Maven repository during resolution. The main
+derivation copies the cached repo to `$HOME/.m2/repository` and makes it
+writable before building.
+
+### 5. `autoPatchelfHook` + `wrapGAppsHook3`
+
+The Eclipse native launcher (`modelio` binary) needs the NixOS dynamic linker
+patched in — `autoPatchelfHook` handles this automatically. GTK/GLib environment
+variables are handled by `wrapGAppsHook3`, but `dontWrapGApps = true` is set so
+that we control wrapper arguments ourselves via `makeWrapper` +
+`gappsWrapperArgs`.
+
+### 6. FOD hash maintenance
+
+The `outputHash` in `mvnDeps` pins the exact set of fetched dependencies. When
+upstream dependencies change, this hash must be updated. See below.
+
+## Updating the FOD Hash
+
+When Maven dependencies change (e.g., after bumping a version in a `pom.xml`),
+the `outputHash` in `nix/package.nix` must be updated:
+
+1. Set the hash to a placeholder:
+   ```nix
+   outputHash = lib.fakeHash;
+   ```
+
+2. Attempt a build:
+   ```bash
+   nix build 2>&1
+   ```
+
+3. The build will fail with a hash mismatch. Copy the `got:` hash from the
+   error message.
+
+4. Replace `lib.fakeHash` with the real hash:
+   ```nix
+   outputHash = "sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=";
+   ```
+
+5. Rebuild to confirm:
+   ```bash
+   nix build
+   ```

--- a/nix/container-run.nix
+++ b/nix/container-run.nix
@@ -1,0 +1,25 @@
+{ writeShellApplication, docker, xorg, container, }:
+
+let version = "5.4.1";
+in writeShellApplication {
+  name = "modelio-container-run";
+  runtimeInputs = [ docker xorg.xhost ];
+  text = ''
+    echo "Loading Modelio container image..."
+    docker load < ${container}
+
+    # Allow the container to connect to the host X server
+    xhost +local:docker 2>/dev/null || true
+
+    echo "Starting Modelio ${version} in Docker..."
+    exec docker run --rm \
+      -e DISPLAY="''${DISPLAY:-:0}" \
+      -e XAUTHORITY=/tmp/.Xauthority \
+      -v "''${XAUTHORITY:-$HOME/.Xauthority}:/tmp/.Xauthority:ro" \
+      -v /tmp/.X11-unix:/tmp/.X11-unix \
+      -v "''${HOME}/.modelio:/root/.modelio" \
+      -v "''${PWD}:/workspace" \
+      --network=host \
+      modelio:${version}
+  '';
+}

--- a/nix/container.nix
+++ b/nix/container.nix
@@ -1,28 +1,15 @@
-{
-  dockerTools,
-  modelio,
-  bash,
-  coreutils,
-  cacert,
-}:
+{ dockerTools, modelio, bash, coreutils, cacert, }:
 
 dockerTools.buildLayeredImage {
   name = "modelio";
   tag = modelio.version;
 
-  contents = [
-    modelio
-    bash
-    coreutils
-    cacert
-  ];
+  contents = [ modelio bash coreutils cacert ];
 
   config = {
     Cmd = [ "${modelio}/bin/modelio" ];
-    Env = [
-      "DISPLAY=:99"
-      "SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt"
-    ];
+    Env =
+      [ "DISPLAY=:99" "SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt" ];
     Volumes = {
       "/workspace" = { };
       "/root/.modelio" = { };

--- a/nix/container.nix
+++ b/nix/container.nix
@@ -1,0 +1,31 @@
+{
+  dockerTools,
+  modelio,
+  bash,
+  coreutils,
+  cacert,
+}:
+
+dockerTools.buildLayeredImage {
+  name = "modelio";
+  tag = modelio.version;
+
+  contents = [
+    modelio
+    bash
+    coreutils
+    cacert
+  ];
+
+  config = {
+    Cmd = [ "${modelio}/bin/modelio" ];
+    Env = [
+      "DISPLAY=:99"
+      "SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt"
+    ];
+    Volumes = {
+      "/workspace" = { };
+      "/root/.modelio" = { };
+    };
+  };
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,74 @@
+{ jdk11 }: {
+  version = "5.4.1";
+
+  # Tycho needs toolchain entries for both JavaSE-1.8 and JavaSE-11 BREE declarations
+  setupToolchains = ''
+    mkdir -p $HOME/.m2
+    cat > $HOME/.m2/toolchains.xml <<XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0
+        http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+      <toolchain>
+        <type>jdk</type>
+        <provides>
+          <version>1.8</version>
+          <vendor>adoptOpenJDK</vendor>
+          <id>JavaSE-1.8</id>
+        </provides>
+        <configuration>
+          <jdkHome>${jdk11}</jdkHome>
+        </configuration>
+      </toolchain>
+      <toolchain>
+        <type>jdk</type>
+        <provides>
+          <version>11</version>
+          <vendor>adoptOpenJDK</vendor>
+          <id>JavaSE-11</id>
+        </provides>
+        <configuration>
+          <jdkHome>${jdk11}</jdkHome>
+        </configuration>
+      </toolchain>
+    </toolchains>
+    XML
+    export JAVA_HOME="${jdk11}"
+  '';
+
+  # ~26 directories in build.properties bin.includes aren't tracked by git
+  fixBuildProperties = ''
+    find . -name build.properties -exec sh -c '
+      dir=$(dirname "$1")
+      grep -A100 "^bin\.includes" "$1" | \
+        sed "/^[a-zA-Z]/{ /^bin\.includes/!q; }" | \
+        tr "," "\n" | sed "s/.*=//; s/\\\\//; s/^[[:space:]]*//; s/[[:space:]]*$//" | \
+        grep "/" | grep -v "^\." | while read -r entry; do
+          entry="''${entry%/}"
+          [ ! -e "$dir/$entry" ] && mkdir -p "$dir/$entry"
+        done
+    ' _ {} \;
+  '';
+
+  # Native libraries needed at runtime (GTK, X11, WebKit, etc.)
+  runtimeLibs = { gtk3, glib, xorg, freetype, fontconfig, zlib, libsecret
+    , webkitgtk_4_0, libGL, alsa-lib, stdenv, }: [
+      gtk3
+      glib
+      xorg.libX11
+      xorg.libXtst
+      xorg.libXrender
+      xorg.libXi
+      xorg.libXext
+      xorg.libXxf86vm
+      freetype
+      fontconfig
+      zlib
+      libsecret
+      webkitgtk_4_0
+      libGL
+      alsa-lib
+      stdenv.cc.cc.lib
+    ];
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -53,7 +53,7 @@
 
   # Native libraries needed at runtime (GTK, X11, WebKit, etc.)
   runtimeLibs = { gtk3, glib, xorg, freetype, fontconfig, zlib, libsecret
-    , webkitgtk_4_0, libGL, alsa-lib, stdenv, }: [
+    , webkitgtk_4_1, libGL, alsa-lib, stdenv, }: [
       gtk3
       glib
       xorg.libX11
@@ -66,7 +66,7 @@
       fontconfig
       zlib
       libsecret
-      webkitgtk_4_0
+      webkitgtk_4_1
       libGL
       alsa-lib
       stdenv.cc.cc.lib

--- a/nix/maven-deps.nix
+++ b/nix/maven-deps.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, maven, jdk11, modelio-src, }:
+
+let shared = import ./lib.nix { inherit jdk11; };
+in stdenv.mkDerivation {
+  pname = "modelio-maven-deps";
+  inherit (shared) version;
+  src = modelio-src;
+
+  nativeBuildInputs = [ maven jdk11 ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$(mktemp -d)
+
+    ${shared.setupToolchains}
+    ${shared.fixBuildProperties}
+
+    mvn install \
+      -f AGGREGATOR/pom.xml \
+      -t $HOME/.m2/toolchains.xml \
+      -Dmaven.repo.local=$out/.m2/repository \
+      -DskipTests \
+      -Dtycho.localArtifacts=ignore \
+      -Dproject.build.outputTimestamp=1980-01-01T00:00:02Z \
+      --batch-mode
+
+    mvn package \
+      -f products/pom.xml \
+      -Pproduct.org,platform.linux \
+      -t $HOME/.m2/toolchains.xml \
+      -Dmaven.repo.local=$out/.m2/repository \
+      -DskipTests \
+      -Dproject.build.outputTimestamp=1980-01-01T00:00:02Z \
+      --batch-mode
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Remove non-deterministic files (timestamps, repo metadata)
+    find $out -type f \( \
+      -name \*.lastUpdated \
+      -o -name resolver-status.properties \
+      -o -name _remote.repositories \
+      -o -name "maven-metadata-*.xml" \) \
+      -delete
+
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "sha256-yGzIWw8O8kiUuubkJnTRsrArz/q6FAXaYOn0rHVsqB4=";
+
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -19,6 +19,7 @@
   alsa-lib,
   copyDesktopItems,
   makeDesktopItem,
+  modelio-src,
 }:
 
 let
@@ -26,12 +27,12 @@ let
   version = "5.4.1";
 
   # Phase A: Fixed-output derivation to cache Maven/Tycho dependencies.
-  # After the first build attempt, replace lib.fakeHash with the real hash
-  # from the error message.
+  # Uses pinned source (modelio-src flake input) so local edits don't
+  # invalidate the cache. Update the pin with: nix flake update modelio-src
   mvnDeps = stdenv.mkDerivation {
     pname = "${pname}-maven-deps";
     inherit version;
-    inherit src;
+    src = modelio-src;
 
     nativeBuildInputs = [
       maven
@@ -116,7 +117,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-pHS8OIdOXixwBBCH4detJMbZEduX54xekzg3NcK3+DA=";
+    outputHash = "sha256-t/kjjK4obD4jaQ5+skv2LQ48NuNvSkcXh+zankKapbI=";
 
     impureEnvVars = lib.fetchers.proxyImpureEnvVars;
   };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,145 +1,27 @@
-{
-  lib,
-  stdenv,
-  jdk,
-  maven,
-  jdk11,
-  makeWrapper,
-  wrapGAppsHook3,
-  autoPatchelfHook,
-  gtk3,
-  glib,
-  xorg,
-  freetype,
-  fontconfig,
-  zlib,
-  libsecret,
-  webkitgtk_4_0,
-  libGL,
-  alsa-lib,
-  copyDesktopItems,
-  makeDesktopItem,
-  modelio-src,
-}:
+{ lib, stdenv, jdk, maven, jdk11, makeWrapper, wrapGAppsHook3, autoPatchelfHook
+, gtk3, glib, xorg, freetype, fontconfig, zlib, libsecret, webkitgtk_4_0, libGL
+, alsa-lib, copyDesktopItems, makeDesktopItem, modelio-src, mvnDeps, }:
 
 let
-  pname = "modelio";
-  version = "5.4.1";
+  shared = import ./lib.nix { inherit jdk11; };
 
-  # Phase A: Fixed-output derivation to cache Maven/Tycho dependencies.
-  # Uses pinned source (modelio-src flake input) so local edits don't
-  # invalidate the cache. Update the pin with: nix flake update modelio-src
-  mvnDeps = stdenv.mkDerivation {
-    pname = "${pname}-maven-deps";
-    inherit version;
-    src = modelio-src;
-
-    nativeBuildInputs = [
-      maven
-      jdk11
-    ];
-
-    buildPhase = ''
-      runHook preBuild
-
-      export HOME=$(mktemp -d)
-
-      # Generate toolchains.xml for Tycho
-      mkdir -p $HOME/.m2
-      cat > $HOME/.m2/toolchains.xml <<XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0
-          http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
-        <toolchain>
-          <type>jdk</type>
-          <provides>
-            <version>1.8</version>
-            <vendor>adoptOpenJDK</vendor>
-            <id>JavaSE-1.8</id>
-          </provides>
-          <configuration>
-            <jdkHome>${jdk11}</jdkHome>
-          </configuration>
-        </toolchain>
-        <toolchain>
-          <type>jdk</type>
-          <provides>
-            <version>11</version>
-            <vendor>adoptOpenJDK</vendor>
-            <id>JavaSE-11</id>
-          </provides>
-          <configuration>
-            <jdkHome>${jdk11}</jdkHome>
-          </configuration>
-        </toolchain>
-      </toolchains>
-      XML
-
-      export JAVA_HOME="${jdk11}"
-
-      # Create missing directories referenced in build.properties bin.includes (not tracked by git)
-      find . -name build.properties -exec sh -c '
-        dir=$(dirname "$1")
-        grep -A100 "^bin\.includes" "$1" | \
-          sed "/^[a-zA-Z]/{ /^bin\.includes/!q; }" | \
-          tr "," "\n" | sed "s/.*=//; s/\\\\//; s/^[[:space:]]*//; s/[[:space:]]*$//" | \
-          grep "/" | grep -v "^\." | while read -r entry; do
-            entry="''${entry%/}"
-            [ ! -e "$dir/$entry" ] && mkdir -p "$dir/$entry"
-          done
-      ' _ {} \;
-
-      # Build everything, caching deps into $out
-      mvn install \
-        -f AGGREGATOR/pom.xml \
-        -t $HOME/.m2/toolchains.xml \
-        -Dmaven.repo.local=$out/.m2/repository \
-        -DskipTests \
-        -Dtycho.localArtifacts=ignore \
-        --batch-mode
-
-      mvn package \
-        -f products/pom.xml \
-        -Pproduct.org,platform.linux \
-        -t $HOME/.m2/toolchains.xml \
-        -Dmaven.repo.local=$out/.m2/repository \
-        -DskipTests \
-        --batch-mode
-
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      # deps are already in $out/.m2/repository from buildPhase
-    '';
-
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-    outputHash = "sha256-t/kjjK4obD4jaQ5+skv2LQ48NuNvSkcXh+zankKapbI=";
-
-    impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+  libs = shared.runtimeLibs {
+    inherit gtk3 glib xorg freetype fontconfig zlib libsecret webkitgtk_4_0
+      libGL alsa-lib stdenv;
   };
 
   src = lib.cleanSourceWith {
     src = ./..;
-    filter =
-      path: type:
-      let
-        relPath = lib.removePrefix (toString ./..) path;
-      in
-      # Exclude nix files and git from the source
-      !(lib.hasPrefix "/nix" relPath)
-      && !(lib.hasPrefix "/flake" relPath)
-      && !(lib.hasPrefix "/.git" relPath)
-      && !(lib.hasSuffix ".nix" relPath)
+    filter = path: type:
+      let relPath = lib.removePrefix (toString ./..) path;
+      in !(lib.hasPrefix "/nix" relPath) && !(lib.hasPrefix "/flake" relPath)
+      && !(lib.hasPrefix "/.git" relPath) && !(lib.hasSuffix ".nix" relPath)
       && !(lib.hasSuffix "flake.lock" relPath);
   };
-
-in
-stdenv.mkDerivation {
-  inherit pname version src;
+in stdenv.mkDerivation {
+  pname = "modelio";
+  inherit (shared) version;
+  inherit src;
 
   nativeBuildInputs = [
     maven
@@ -150,24 +32,7 @@ stdenv.mkDerivation {
     copyDesktopItems
   ];
 
-  buildInputs = [
-    gtk3
-    glib
-    xorg.libX11
-    xorg.libXtst
-    xorg.libXrender
-    xorg.libXi
-    xorg.libXext
-    xorg.libXxf86vm
-    freetype
-    fontconfig
-    zlib
-    libsecret
-    webkitgtk_4_0
-    libGL
-    alsa-lib
-    stdenv.cc.cc.lib # libstdc++
-  ];
+  buildInputs = libs;
 
   dontWrapGApps = true;
 
@@ -176,58 +41,13 @@ stdenv.mkDerivation {
 
     export HOME=$(mktemp -d)
 
-    # Generate toolchains.xml
-    mkdir -p $HOME/.m2
-    cat > $HOME/.m2/toolchains.xml <<XML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0
-        http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
-      <toolchain>
-        <type>jdk</type>
-        <provides>
-          <version>1.8</version>
-          <vendor>adoptOpenJDK</vendor>
-          <id>JavaSE-1.8</id>
-        </provides>
-        <configuration>
-          <jdkHome>${jdk11}</jdkHome>
-        </configuration>
-      </toolchain>
-      <toolchain>
-        <type>jdk</type>
-        <provides>
-          <version>11</version>
-          <vendor>adoptOpenJDK</vendor>
-          <id>JavaSE-11</id>
-        </provides>
-        <configuration>
-          <jdkHome>${jdk11}</jdkHome>
-        </configuration>
-      </toolchain>
-    </toolchains>
-    XML
-
-    export JAVA_HOME="${jdk11}"
-
-    # Create missing directories referenced in build.properties bin.includes (not tracked by git)
-    find . -name build.properties -exec sh -c '
-      dir=$(dirname "$1")
-      grep -A100 "^bin\.includes" "$1" | \
-        sed "/^[a-zA-Z]/{ /^bin\.includes/!q; }" | \
-        tr "," "\n" | sed "s/.*=//; s/\\\\//; s/^[[:space:]]*//; s/[[:space:]]*$//" | \
-        grep "/" | grep -v "^\." | while read -r entry; do
-          entry="''${entry%/}"
-          [ ! -e "$dir/$entry" ] && mkdir -p "$dir/$entry"
-        done
-    ' _ {} \;
+    ${shared.setupToolchains}
+    ${shared.fixBuildProperties}
 
     # Copy cached deps to writable location (Tycho needs to create .tycholock files)
     cp -r ${mvnDeps}/.m2/repository $HOME/.m2/repository
     chmod -R u+w $HOME/.m2/repository
 
-    # Build using cached dependencies (offline)
     mvn install \
       -f AGGREGATOR/pom.xml \
       -t $HOME/.m2/toolchains.xml \
@@ -252,7 +72,6 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    # Extract the product tarball
     tarball=$(find products/target/products -name '*linux*tar.gz' | head -1)
     if [ -z "$tarball" ]; then
       echo "ERROR: No linux tarball found in products/target/products/"
@@ -262,43 +81,22 @@ stdenv.mkDerivation {
 
     mkdir -p $out/lib
     tar xf "$tarball" -C $out/lib
-    mv "$out/lib/Modelio 5.4.1" $out/lib/modelio
+    mv "$out/lib/Modelio ${shared.version}" $out/lib/modelio
 
     # Replace bundled JRE with Nix JDK
     rm -rf $out/lib/modelio/jre
     ln -s ${jdk} $out/lib/modelio/jre
 
-    # Create wrapper script
     mkdir -p $out/bin
     makeWrapper $out/lib/modelio/modelio $out/bin/modelio \
       "''${gappsWrapperArgs[@]}" \
       --set JAVA_HOME "${jdk}" \
-      --prefix LD_LIBRARY_PATH : "${
-        lib.makeLibraryPath [
-          gtk3
-          glib
-          xorg.libX11
-          xorg.libXtst
-          xorg.libXrender
-          xorg.libXi
-          xorg.libXext
-          xorg.libXxf86vm
-          freetype
-          fontconfig
-          zlib
-          libsecret
-          webkitgtk_4_0
-          libGL
-          alsa-lib
-          stdenv.cc.cc.lib
-        ]
-      }" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libs}" \
       --add-flags "-Xms1024m" \
       --add-flags "-Xmx4096m" \
       --add-flags "-Dpython.console.encoding=UTF-8" \
       --add-flags "-Dorg.eclipse.swt.internal.webkitgtk.ignoretlserrors=true"
 
-    # Install icon
     install -Dm644 products/icons/modelio.xpm $out/share/pixmaps/modelio.xpm
 
     runHook postInstall
@@ -311,10 +109,7 @@ stdenv.mkDerivation {
       exec = "modelio";
       icon = "modelio";
       comment = "Open-source UML/BPMN modeling tool";
-      categories = [
-        "Development"
-        "IDE"
-      ];
+      categories = [ "Development" "IDE" ];
     })
   ];
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,327 @@
+{
+  lib,
+  stdenv,
+  jdk,
+  maven,
+  jdk11,
+  makeWrapper,
+  wrapGAppsHook3,
+  autoPatchelfHook,
+  gtk3,
+  glib,
+  xorg,
+  freetype,
+  fontconfig,
+  zlib,
+  libsecret,
+  webkitgtk_4_0,
+  libGL,
+  alsa-lib,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+
+let
+  pname = "modelio";
+  version = "5.4.1";
+
+  # Phase A: Fixed-output derivation to cache Maven/Tycho dependencies.
+  # After the first build attempt, replace lib.fakeHash with the real hash
+  # from the error message.
+  mvnDeps = stdenv.mkDerivation {
+    pname = "${pname}-maven-deps";
+    inherit version;
+    inherit src;
+
+    nativeBuildInputs = [
+      maven
+      jdk11
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME=$(mktemp -d)
+
+      # Generate toolchains.xml for Tycho
+      mkdir -p $HOME/.m2
+      cat > $HOME/.m2/toolchains.xml <<XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0
+          http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+        <toolchain>
+          <type>jdk</type>
+          <provides>
+            <version>1.8</version>
+            <vendor>adoptOpenJDK</vendor>
+            <id>JavaSE-1.8</id>
+          </provides>
+          <configuration>
+            <jdkHome>${jdk11}</jdkHome>
+          </configuration>
+        </toolchain>
+        <toolchain>
+          <type>jdk</type>
+          <provides>
+            <version>11</version>
+            <vendor>adoptOpenJDK</vendor>
+            <id>JavaSE-11</id>
+          </provides>
+          <configuration>
+            <jdkHome>${jdk11}</jdkHome>
+          </configuration>
+        </toolchain>
+      </toolchains>
+      XML
+
+      export JAVA_HOME="${jdk11}"
+
+      # Create missing directories referenced in build.properties bin.includes (not tracked by git)
+      find . -name build.properties -exec sh -c '
+        dir=$(dirname "$1")
+        grep -A100 "^bin\.includes" "$1" | \
+          sed "/^[a-zA-Z]/{ /^bin\.includes/!q; }" | \
+          tr "," "\n" | sed "s/.*=//; s/\\\\//; s/^[[:space:]]*//; s/[[:space:]]*$//" | \
+          grep "/" | grep -v "^\." | while read -r entry; do
+            entry="''${entry%/}"
+            [ ! -e "$dir/$entry" ] && mkdir -p "$dir/$entry"
+          done
+      ' _ {} \;
+
+      # Build everything, caching deps into $out
+      mvn install \
+        -f AGGREGATOR/pom.xml \
+        -t $HOME/.m2/toolchains.xml \
+        -Dmaven.repo.local=$out/.m2/repository \
+        -DskipTests \
+        -Dtycho.localArtifacts=ignore \
+        --batch-mode
+
+      mvn package \
+        -f products/pom.xml \
+        -Pproduct.org,platform.linux \
+        -t $HOME/.m2/toolchains.xml \
+        -Dmaven.repo.local=$out/.m2/repository \
+        -DskipTests \
+        --batch-mode
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      # deps are already in $out/.m2/repository from buildPhase
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-pHS8OIdOXixwBBCH4detJMbZEduX54xekzg3NcK3+DA=";
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+  };
+
+  src = lib.cleanSourceWith {
+    src = ./..;
+    filter =
+      path: type:
+      let
+        relPath = lib.removePrefix (toString ./..) path;
+      in
+      # Exclude nix files and git from the source
+      !(lib.hasPrefix "/nix" relPath)
+      && !(lib.hasPrefix "/flake" relPath)
+      && !(lib.hasPrefix "/.git" relPath)
+      && !(lib.hasSuffix ".nix" relPath)
+      && !(lib.hasSuffix "flake.lock" relPath);
+  };
+
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    maven
+    jdk11
+    makeWrapper
+    wrapGAppsHook3
+    autoPatchelfHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    xorg.libX11
+    xorg.libXtst
+    xorg.libXrender
+    xorg.libXi
+    xorg.libXext
+    xorg.libXxf86vm
+    freetype
+    fontconfig
+    zlib
+    libsecret
+    webkitgtk_4_0
+    libGL
+    alsa-lib
+    stdenv.cc.cc.lib # libstdc++
+  ];
+
+  dontWrapGApps = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$(mktemp -d)
+
+    # Generate toolchains.xml
+    mkdir -p $HOME/.m2
+    cat > $HOME/.m2/toolchains.xml <<XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0
+        http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+      <toolchain>
+        <type>jdk</type>
+        <provides>
+          <version>1.8</version>
+          <vendor>adoptOpenJDK</vendor>
+          <id>JavaSE-1.8</id>
+        </provides>
+        <configuration>
+          <jdkHome>${jdk11}</jdkHome>
+        </configuration>
+      </toolchain>
+      <toolchain>
+        <type>jdk</type>
+        <provides>
+          <version>11</version>
+          <vendor>adoptOpenJDK</vendor>
+          <id>JavaSE-11</id>
+        </provides>
+        <configuration>
+          <jdkHome>${jdk11}</jdkHome>
+        </configuration>
+      </toolchain>
+    </toolchains>
+    XML
+
+    export JAVA_HOME="${jdk11}"
+
+    # Create missing directories referenced in build.properties bin.includes (not tracked by git)
+    find . -name build.properties -exec sh -c '
+      dir=$(dirname "$1")
+      grep -A100 "^bin\.includes" "$1" | \
+        sed "/^[a-zA-Z]/{ /^bin\.includes/!q; }" | \
+        tr "," "\n" | sed "s/.*=//; s/\\\\//; s/^[[:space:]]*//; s/[[:space:]]*$//" | \
+        grep "/" | grep -v "^\." | while read -r entry; do
+          entry="''${entry%/}"
+          [ ! -e "$dir/$entry" ] && mkdir -p "$dir/$entry"
+        done
+    ' _ {} \;
+
+    # Copy cached deps to writable location (Tycho needs to create .tycholock files)
+    cp -r ${mvnDeps}/.m2/repository $HOME/.m2/repository
+    chmod -R u+w $HOME/.m2/repository
+
+    # Build using cached dependencies (offline)
+    mvn install \
+      -f AGGREGATOR/pom.xml \
+      -t $HOME/.m2/toolchains.xml \
+      -Dmaven.repo.local=$HOME/.m2/repository \
+      --offline \
+      -DskipTests \
+      -Dtycho.localArtifacts=ignore \
+      --batch-mode
+
+    mvn package \
+      -f products/pom.xml \
+      -Pproduct.org,platform.linux \
+      -t $HOME/.m2/toolchains.xml \
+      -Dmaven.repo.local=$HOME/.m2/repository \
+      --offline \
+      -DskipTests \
+      --batch-mode
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Extract the product tarball
+    tarball=$(find products/target/products -name '*linux*tar.gz' | head -1)
+    if [ -z "$tarball" ]; then
+      echo "ERROR: No linux tarball found in products/target/products/"
+      find products/target/ -name '*.tar.gz' || true
+      exit 1
+    fi
+
+    mkdir -p $out/lib
+    tar xf "$tarball" -C $out/lib
+    mv "$out/lib/Modelio 5.4.1" $out/lib/modelio
+
+    # Replace bundled JRE with Nix JDK
+    rm -rf $out/lib/modelio/jre
+    ln -s ${jdk} $out/lib/modelio/jre
+
+    # Create wrapper script
+    mkdir -p $out/bin
+    makeWrapper $out/lib/modelio/modelio $out/bin/modelio \
+      "''${gappsWrapperArgs[@]}" \
+      --set JAVA_HOME "${jdk}" \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          gtk3
+          glib
+          xorg.libX11
+          xorg.libXtst
+          xorg.libXrender
+          xorg.libXi
+          xorg.libXext
+          xorg.libXxf86vm
+          freetype
+          fontconfig
+          zlib
+          libsecret
+          webkitgtk_4_0
+          libGL
+          alsa-lib
+          stdenv.cc.cc.lib
+        ]
+      }" \
+      --add-flags "-Xms1024m" \
+      --add-flags "-Xmx4096m" \
+      --add-flags "-Dpython.console.encoding=UTF-8" \
+      --add-flags "-Dorg.eclipse.swt.internal.webkitgtk.ignoretlserrors=true"
+
+    # Install icon
+    install -Dm644 products/icons/modelio.xpm $out/share/pixmaps/modelio.xpm
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "modelio";
+      desktopName = "Modelio";
+      exec = "modelio";
+      icon = "modelio";
+      comment = "Open-source UML/BPMN modeling tool";
+      categories = [
+        "Development"
+        "IDE"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Open-source modeling environment (UML, BPMN, ArchiMate)";
+    homepage = "https://www.modelio.org";
+    license = lib.licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "modelio";
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, jdk, maven, jdk11, makeWrapper, wrapGAppsHook3, autoPatchelfHook
-, gtk3, glib, xorg, freetype, fontconfig, zlib, libsecret, webkitgtk_4_0, libGL
+, gtk3, glib, xorg, freetype, fontconfig, zlib, libsecret, webkitgtk_4_1, libGL
 , alsa-lib, copyDesktopItems, makeDesktopItem, modelio-src, mvnDeps, }:
 
 let
   shared = import ./lib.nix { inherit jdk11; };
 
   libs = shared.runtimeLibs {
-    inherit gtk3 glib xorg freetype fontconfig zlib libsecret webkitgtk_4_0
+    inherit gtk3 glib xorg freetype fontconfig zlib libsecret webkitgtk_4_1
       libGL alsa-lib stdenv;
   };
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,78 @@
+{
+  mkShell,
+  maven,
+  jdk11,
+  gtk3,
+  glib,
+  xorg,
+  freetype,
+  fontconfig,
+  zlib,
+  libsecret,
+}:
+
+mkShell {
+  packages = [
+    maven
+    jdk11
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    xorg.libX11
+    xorg.libXtst
+    xorg.libXrender
+    freetype
+    fontconfig
+    zlib
+    libsecret
+  ];
+
+  shellHook = ''
+    export JAVA_HOME="${jdk11}"
+
+    # Auto-generate toolchains.xml for Tycho
+    mkdir -p "$HOME/.m2"
+    cat > "$HOME/.m2/toolchains.xml" <<XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0
+        http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+      <toolchain>
+        <type>jdk</type>
+        <provides>
+          <version>1.8</version>
+          <vendor>adoptOpenJDK</vendor>
+          <id>JavaSE-1.8</id>
+        </provides>
+        <configuration>
+          <jdkHome>${jdk11}</jdkHome>
+        </configuration>
+      </toolchain>
+      <toolchain>
+        <type>jdk</type>
+        <provides>
+          <version>11</version>
+          <vendor>adoptOpenJDK</vendor>
+          <id>JavaSE-11</id>
+        </provides>
+        <configuration>
+          <jdkHome>${jdk11}</jdkHome>
+        </configuration>
+      </toolchain>
+    </toolchains>
+    XML
+
+    echo "Modelio dev shell"
+    echo "  JAVA_HOME=$JAVA_HOME"
+    echo "  java:  $(java -version 2>&1 | head -1)"
+    echo "  maven: $(mvn --version 2>&1 | head -1)"
+    echo ""
+    echo "Build steps:"
+    echo "  1. mvn clean install -f AGGREGATOR/pom.xml"
+    echo "  2. mvn package -f products/pom.xml -Pproduct.org,platform.linux"
+    echo "  Output: products/target/products/*linux*.tar.gz"
+  '';
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,21 +1,9 @@
-{
-  mkShell,
-  maven,
-  jdk11,
-  gtk3,
-  glib,
-  xorg,
-  freetype,
-  fontconfig,
-  zlib,
-  libsecret,
-}:
+{ mkShell, maven, jdk11, gtk3, glib, xorg, freetype, fontconfig, zlib, libsecret
+, }:
 
-mkShell {
-  packages = [
-    maven
-    jdk11
-  ];
+let shared = import ./lib.nix { inherit jdk11; };
+in mkShell {
+  packages = [ maven jdk11 ];
 
   buildInputs = [
     gtk3
@@ -30,40 +18,7 @@ mkShell {
   ];
 
   shellHook = ''
-    export JAVA_HOME="${jdk11}"
-
-    # Auto-generate toolchains.xml for Tycho
-    mkdir -p "$HOME/.m2"
-    cat > "$HOME/.m2/toolchains.xml" <<XML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0
-        http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
-      <toolchain>
-        <type>jdk</type>
-        <provides>
-          <version>1.8</version>
-          <vendor>adoptOpenJDK</vendor>
-          <id>JavaSE-1.8</id>
-        </provides>
-        <configuration>
-          <jdkHome>${jdk11}</jdkHome>
-        </configuration>
-      </toolchain>
-      <toolchain>
-        <type>jdk</type>
-        <provides>
-          <version>11</version>
-          <vendor>adoptOpenJDK</vendor>
-          <id>JavaSE-11</id>
-        </provides>
-        <configuration>
-          <jdkHome>${jdk11}</jdkHome>
-        </configuration>
-      </toolchain>
-    </toolchains>
-    XML
+    ${shared.setupToolchains}
 
     echo "Modelio dev shell"
     echo "  JAVA_HOME=$JAVA_HOME"

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -1,0 +1,52 @@
+{
+  runCommand,
+  writeShellApplication,
+  modelio,
+  xvfb-run,
+  coreutils,
+  procps,
+}:
+
+let
+  smokeTest = writeShellApplication {
+    name = "modelio-smoke-test";
+    runtimeInputs = [
+      modelio
+      xvfb-run
+      coreutils
+      procps
+    ];
+    text = ''
+      echo "=== Modelio smoke test ==="
+
+      # Verify binary exists and is executable
+      test -x "${modelio}/bin/modelio"
+      echo "PASS: modelio binary exists"
+
+      # Verify JRE symlink
+      test -d "${modelio}/lib/modelio/jre"
+      echo "PASS: JRE directory exists"
+
+      # Launch with xvfb and check it starts
+      xvfb-run -a "${modelio}/bin/modelio" &
+      PID=$!
+      sleep 15
+
+      if kill -0 "$PID" 2>/dev/null; then
+        echo "PASS: modelio process running after 15s"
+        kill "$PID" || true
+        wait "$PID" 2>/dev/null || true
+        echo "PASS: modelio exited cleanly"
+      else
+        echo "FAIL: modelio process died before 15s"
+        exit 1
+      fi
+
+      echo "=== All smoke tests passed ==="
+    '';
+  };
+in
+runCommand "modelio-smoke-test" { nativeBuildInputs = [ smokeTest ]; } ''
+  modelio-smoke-test
+  touch $out
+''

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -1,21 +1,9 @@
-{
-  runCommand,
-  writeShellApplication,
-  modelio,
-  xvfb-run,
-  coreutils,
-  procps,
-}:
+{ runCommand, writeShellApplication, modelio, xvfb-run, coreutils, procps, }:
 
 let
   smokeTest = writeShellApplication {
     name = "modelio-smoke-test";
-    runtimeInputs = [
-      modelio
-      xvfb-run
-      coreutils
-      procps
-    ];
+    runtimeInputs = [ modelio xvfb-run coreutils procps ];
     text = ''
       echo "=== Modelio smoke test ==="
 
@@ -45,8 +33,7 @@ let
       echo "=== All smoke tests passed ==="
     '';
   };
-in
-runCommand "modelio-smoke-test" { nativeBuildInputs = [ smokeTest ]; } ''
+in runCommand "modelio-smoke-test" { nativeBuildInputs = [ smokeTest ]; } ''
   modelio-smoke-test
   touch $out
 ''


### PR DESCRIPTION
## Summary

- Add a Nix flake providing reproducible source builds of Modelio 5.4.1 using a two-phase fixed-output derivation (FOD) approach for Maven/Tycho dependency caching
- Include dev shell (`nix develop`), OCI container image (`nix build .#container`), xvfb-based smoke test (`nix flake check`), and `nix run` support
- Add `nix/README.md` documenting usage, architecture, and design decisions

## What's included

| File | Purpose |
|------|---------|
| `flake.nix` | Flake entry point with formatter |
| `flake.lock` | Pinned nixpkgs 24.11 + flake-utils |
| `nix/package.nix` | Two-phase source build (FOD + offline build) |
| `nix/shell.nix` | Dev shell with Maven, JDK 11, native libs |
| `nix/container.nix` | Minimal OCI container image |
| `nix/test.nix` | Smoke test (binary exists, JRE linked, process starts) |
| `nix/README.md` | Documentation |

## Test plan

- [ ] `nix build` completes successfully
- [ ] `nix run` launches Modelio
- [ ] `nix develop` provides working Maven + JDK environment
- [ ] `nix build .#container` produces loadable OCI image
- [ ] `nix flake check` passes smoke tests
- [ ] `nix fmt` runs cleanly (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)